### PR TITLE
Add single-quoted attributes.

### DIFF
--- a/lib/prawn/icon/parser.rb
+++ b/lib/prawn/icon/parser.rb
@@ -39,6 +39,8 @@ module Prawn
 
       TAG_REGEX     = /<icon[^>]*>[^<]*<\/icon>/mi
 
+      ATTR_REGEX    = /(?<attr>[a-zA-Z]*)=["|'](?<val>(\w*[^["|']]))["|']/mi
+
       class << self
         def format(document, string)
           tokens  = string.scan(PARSER_REGEX)
@@ -58,16 +60,22 @@ module Prawn
           tokens.each do |token|
             # Skip the closing tag
             next if token =~ /<\/icon>/i
-
             icon = {}
 
-            # TODO: Only support double quotes?
-            size  = /size="([^"]*)"/i.match(token)
-            color = /color="([^"]*)"/i.match(token)
+            # Convert [[1,2], [3,4]] to { :1 => 2, :3 => 4 }
+            attrs = token.scan(ATTR_REGEX).inject({}) do |k, v|
+              # If attr == size, we must cast value to float,
+              # else symbolize the key and map it to value
+              val =  if v[0] =~ /size/i
+                       { size: v[1].to_f }
+                     else
+                       { v[0].to_sym => v[1] }
+                     end
 
-            icon[:size]  = size[1].to_f if size
-            icon[:color] = color[1] if color
+              k.merge!(val)
+            end
 
+            icon.merge!(attrs)
             array << icon
           end
 

--- a/lib/prawn/icon/parser.rb
+++ b/lib/prawn/icon/parser.rb
@@ -64,14 +64,7 @@ module Prawn
 
             # Convert [[1,2], [3,4]] to { :1 => 2, :3 => 4 }
             attrs = token.scan(ATTR_REGEX).inject({}) do |k, v|
-              # If attr == size, we must cast value to float,
-              # else symbolize the key and map it to value
-              val =  if v[0] =~ /size/i
-                       { size: v[1].to_f }
-                     else
-                       { v[0].to_sym => v[1] }
-                     end
-
+              val = attr_hash(v)
               k.merge!(val)
             end
 
@@ -127,6 +120,18 @@ module Prawn
           end
 
           icons
+        end
+
+        private
+
+        def attr_hash(value) #:nodoc:
+          # If attr == size, we must cast value to float,
+          # else symbolize the key and map it to value
+          if value[0] =~ /size/i
+            { size: value[1].to_f }
+          else
+            { value[0].to_sym => value[1] }
+          end
         end
       end
     end

--- a/spec/unit/parser_spec.rb
+++ b/spec/unit/parser_spec.rb
@@ -55,6 +55,34 @@ describe Prawn::Icon::Parser do
   end
 
   describe '::config_from_tokens' do
+    it 'should handle attrs with double quotes' do
+      string = '<icon size="20">fa-arrows</icon>'
+      tokens = tokenize_string(string)
+      config = Prawn::Icon::Parser.config_from_tokens(tokens)
+      inner = config.first
+
+      expect(inner[:size]).to eq(20.0)
+    end
+
+    it 'should handle attrs with single quotes' do
+      string = "<icon size='20'>fa-arrows</icon>"
+      tokens = tokenize_string(string)
+      config = Prawn::Icon::Parser.config_from_tokens(tokens)
+      inner = config.first
+
+      expect(inner[:size]).to eq(20.0)
+    end
+
+    it 'should handle both single/double quotes in same string' do
+      string = '<icon color="0099FF" size=\'20\'>fa-arrows</icon>'
+      tokens = tokenize_string(string)
+      config = Prawn::Icon::Parser.config_from_tokens(tokens)
+      inner = config.first
+
+      expect(inner[:size]).to eq(20.0)
+      expect(inner[:color]).to eq('0099FF')
+    end
+
     it 'should return an array containing only an empty hash' do
       string = '<icon>fa-arrows</icon>'
       tokens = tokenize_string(string)


### PR DESCRIPTION
Icon tags now support singly-quoted attributes such as:

```
<icon size='12' color='333333'>fa-arrows</icon>
```

This is useful if you don't want to have to escape quotes for situations where you are interpolating the input string.

Theoretically, you should be able to mix/match single and double quotes, but doing so is guaranteed to be a bad idea.