### PR TITLE
Add prawn as a runtime dependency.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.2
+  - 2.2.0
   - rbx-2
   - jruby-19mode
 matrix:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ When using `inline_format: true`, you may supply `<icon>` tags with `color` and 
 
 ## Specifying Icon Families
 
-Prawn::Icon uses the prefix of an icon key to determine which font family to use to render a particular icon.
+Prawn::Icon uses the prefix of an icon key to determine which font family is used to render a particular icon.
 
 Currently supported prefixes include:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ gem install prawn-icon
 Prawn::Icon was designed to have an API familiar to Prawn. A single icon may be rendered as such:
 
 ```ruby
-require 'prawn'
 require 'prawn/icon'
 
 Prawn::Document.generate('icons.pdf') do |pdf|
@@ -44,7 +43,6 @@ produces:
 You can also provide the `inline_format: true` option to Prawn::Icon:
 
 ```ruby
-require 'prawn'
 require 'prawn/icon'
 
 Prawn::Document.generate('inline_icons.pdf') do |pdf|
@@ -57,6 +55,16 @@ produces:
 ![FontAwesome Beer Inline](https://raw.github.com/jessedoyle/prawn-icon/master/examples/fa-beer-inline.png)
 
 When using `inline_format: true`, you may supply `<icon>` tags with `color` and `size` attributes.
+
+## Specifying Icon Families
+
+Prawn::Icon uses the prefix of an icon key to determine which font family to use to render a particular icon.
+
+Currently supported prefixes include:
+
+* `fa` - Fontawesome (eg. `fa-arrows`)
+* `fi` - Foundation Icons (eg. `fi-compass`)
+* `octicon` - Github Octicons (eg. `octicon-calendar`)
 
 ## How It Works
 

--- a/examples/fontawesome.rb
+++ b/examples/fontawesome.rb
@@ -1,6 +1,5 @@
 # All example code may be executed by calling `rake legend`
 
-require 'prawn'
 require_relative '../lib/prawn/icon'
 require_relative 'example_helper'
 

--- a/examples/foundation_icons.rb
+++ b/examples/foundation_icons.rb
@@ -1,6 +1,5 @@
 # All example code may be executed by calling `rake legend`
 
-require 'prawn'
 require_relative '../lib/prawn/icon'
 require_relative 'example_helper'
 

--- a/examples/octicons.rb
+++ b/examples/octicons.rb
@@ -1,6 +1,5 @@
 # All example code may be executed by calling `rake legend`
 
-require 'prawn'
 require_relative '../lib/prawn/icon'
 require_relative 'example_helper'
 

--- a/lib/prawn/icon.rb
+++ b/lib/prawn/icon.rb
@@ -6,6 +6,7 @@
 #
 # This is free software. Please see the LICENSE and COPYING files for details.
 
+require 'prawn'
 require_relative 'icon/font_data'
 require_relative 'icon/parser'
 

--- a/prawn-icon.gemspec
+++ b/prawn-icon.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   spec.email = ['jdoyle@ualberta.ca']
   spec.licenses = ['RUBY', 'GPL-2', 'GPL-3']
 
-  spec.add_development_dependency('prawn', '~> 1.3')
+  spec.add_dependency('prawn', '>= 1.3.0', '< 3.0.0')
+
   spec.add_development_dependency('pdf-inspector', '~> 1.1.0')
   spec.add_development_dependency('rspec', '~>2.14.1')
   spec.add_development_dependency('rubocop', '~>0.27.0')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@
 require "bundler"
 Bundler.setup
 
-require "prawn"
 require "prawn/icon"
 require 'pdf/inspector'
 require "rspec"


### PR DESCRIPTION
We should no longer assume that users have previously installed Prawn. 

Prawn >= 1.3.0 is now strictly listed as a runtime dependency in the gemspec.