### PR TITLE
Implement inline table icons. #13

### DIFF
--- a/lib/prawn/icon.rb
+++ b/lib/prawn/icon.rb
@@ -23,7 +23,8 @@ module Prawn
 
   # Easy icon font usage within Prawn. Currently
   # supported icon fonts include: FontAwesome,
-  # Zurb Foundicons, and GitHub Octicons.
+  # Zurb Foundicons, GitHub Octicons, as well as
+  # PaymentFont.
   #
   # = Icon Keys
   #
@@ -134,20 +135,23 @@ module Prawn
       # == Parameters:
       # key::
       #   Contains the key to a particular icon within
-      #   a font family. Note that :inline_format is not
-      #   supported as a valid option.
+      #   a font family. The key may contain a string
+      #   with format tags if +inline_format: true+ in
+      #   the +opts+ hash.
       #
       # opts::
       #   A hash of options that may be supplied to the
-      #   underlying text call. Note that :inline_format
-      #   is not supported as a valid option.
+      #   underlying text call.
       #
       # == Returns:
       #   A Hash containing +font+ and +content+ keys
       #   that match the data necessary for the
       #   specified icon.
       #
-      #   eg. { font: 'fa', content: '/uf047' }
+      #   eg. { font: 'fa', content: '\uf047' }
+      #
+      #   Note that the +font+ key will not be set
+      #   if +inline_format: true+.
       #
       # == Examples:
       #   require 'prawn/table'
@@ -161,13 +165,12 @@ module Prawn
       #   pdf.table(data) => (2 x 2 table)
       #
       def table_icon(key, opts = {})
-        if opts.delete(:inline_format)
-          raise Prawn::Errors::UnknownOption,
-                'Inline formatting is not supported.'
+        if opts[:inline_format]
+          content = Icon::Parser.format(self, key)
+          opts.merge(content: content)
+        else
+          make_icon(key, opts).format_hash
         end
-
-        icon = make_icon(key, opts)
-        icon.format_hash
       end
     end
 
@@ -199,7 +202,7 @@ module Prawn
 
     private
 
-    def strip_specifier_from_key(key)
+    def strip_specifier_from_key(key) #:nodoc:
       reg = Regexp.new "#{@data.specifier}-"
       key.sub(reg, '') # Only one specifier
     end

--- a/spec/integration/icon_spec.rb
+++ b/spec/integration/icon_spec.rb
@@ -102,20 +102,49 @@ describe Prawn::Icon::Interface do
   end
 
   describe '::table_icon' do
-    it 'should return a hash with font and content keys' do
-      pdf = create_pdf
-      icon = pdf.table_icon 'fa-arrows'
+    context 'inline_format: false (default)' do
+      it 'should return a hash with font and content keys' do
+        pdf = create_pdf
+        icon = pdf.table_icon 'fa-arrows'
 
-      expect(icon.class).to eq(Hash)
-      expect(icon[:font]).to eq('fa')
-      expect(icon[:content]).to eq("\uf047")
+        expect(icon.class).to eq(Hash)
+        expect(icon[:font]).to eq('fa')
+        expect(icon[:content]).to eq("\uf047")
+      end
     end
 
-    it 'should raise an error if inline_format: true' do
-      pdf = create_pdf
-      proc = Proc.new { pdf.table_icon 'fa-arrows', inline_format: true }
+    context 'inline_format: true' do
+      it 'should convert <icon> to <font> tags' do
+        pdf = create_pdf
+        icon = pdf.table_icon '<icon>fa-user</icon>', inline_format: true
 
-      expect(proc).to raise_error(Prawn::Errors::UnknownOption)
+        expect(icon.class).to eq(Hash)
+        expect(icon[:content]).to eq('<font name="fa"></font>')
+        expect(icon[:inline_format]).to be_true
+      end
+
+      it 'should ignore all other tags' do
+        pdf = create_pdf
+        a = ['<b>BOLD</b> <color rgb="0099FF">BLUE</color>', inline_format: true]
+        icon = pdf.table_icon(*a)
+
+        expect(icon.class).to eq(Hash)
+        expect(icon[:content]).to eq(a[0])
+        expect(icon[:inline_format]).to be_true
+      end
+
+      context 'multiple icons' do
+        it 'should ignore any text not in an icon tag' do
+          pdf = create_pdf
+          a = ['<icon>fa-user</icon> Some Text <icon>fi-laptop</icon>', inline_format: true]
+          out = '<font name="fa"></font> Some Text <font name="fi"></font>'
+          icon = pdf.table_icon(*a)
+
+          expect(icon.class).to eq(Hash)
+          expect(icon[:content]).to eq(out)
+          expect(icon[:inline_format]).to be_true
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This patch adds the ability to supply `table_icon` with `inline_format: true` to allow for multiple icons within a single table cell.

Example:
```ruby
data = [
  [pdf.table_icon('<icon>fa-user</icon> Hello, World! <icon>fa-cloud</icon>', inline_format: true), '2'],
  ['3', '4']
]

pdf.table(data)
```

If finer-grained icon placement is necessary than what is capable with inline formatting, then it is recommended to use `Prawn::Table`'s `colspan` or `subtable` functionality.
