### PR TITLE
Simplify code using Ruby's tap method

### DIFF
--- a/lib/prawn/icon.rb
+++ b/lib/prawn/icon.rb
@@ -78,9 +78,7 @@ module Prawn
       #   inline_format: true
       #
       def icon(key, opts = {})
-        i = make_icon(key, opts)
-        i.render
-        i
+        make_icon(key, opts).tap(&:render)
       end
 
       # Initialize a new icon object, but do

--- a/lib/prawn/icon/font_data.rb
+++ b/lib/prawn/icon/font_data.rb
@@ -79,14 +79,12 @@ module Prawn
       end
 
       def unicode(key)
-        char = yaml[specifier][key]
-
-        unless char
-          raise Prawn::Errors::IconNotFound,
-                "Key: #{specifier}-#{key} not found"
+        yaml[specifier][key].tap do |char|
+          unless char
+            raise Prawn::Errors::IconNotFound,
+                  "Key: #{specifier}-#{key} not found"
+          end
         end
-
-        char
       end
 
       def keys


### PR DESCRIPTION
It was common to see the following code:
```ruby
arr = []

items.each do |i|
  arr << i # something more elaborate here...
end

arr
```

This PR simplifies the codebase by using `tap`:
```ruby
[].tap do |arr|
  items.each do |i|
    arr << i
  end
end
```
