### PR TITLE
Fix Inline Icon Render Position

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,17 @@
 language: ruby
 before_install:
   - gem install bundler
+  - bundle --version
 rvm:
-  - 1.9.3
-  - 2.2.0
-  - rbx-2
-  - jruby-19mode
-
+  - 2.1.0-p0
+  - 2.2.4
+  - 2.3.0
+  - jruby-9.0.5.0
+  - rbx-3.19
 gemfile:
-  - gemfiles/prawn-1.2.1.gemfile
   - gemfiles/prawn-1.3.0.gemfile
-  - gemfiles/prawn-2.0.2.gemfile
+  - gemfiles/prawn-2.1.0.gemfile
   - gemfiles/prawn-master.gemfile
-
 matrix:
-  exclude:
-    - rvm: 1.9.3
-      gemfile: gemfiles/prawn-2.0.2.gemfile
-
-    - rvm: jruby-19mode
-      gemfile: gemfiles/prawn-2.0.2.gemfile
-
-
   allow_failures:
-    - rvm: rbx-2
-    - gemfile: gemfiles/prawn-master.gemfile
+    - rvm: rbx-3.19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.1 - Jun 24, 2016
+
+- BUGFIX: Inline icons now properly render at the correct cursor position with the correct line gap and box leading[#24](https://github.com/jessedoyle/prawn-icon/issues/24). Thanks @ToniTornado for reporting!
+
 # 1.1.0 - March 16, 2016
 
 - Update FontAwesome from v4.4.0 to v4.5.0. See [changelog](http://fontawesome.io/icons#new).

--- a/gemfiles/prawn-1.2.1.gemfile
+++ b/gemfiles/prawn-1.2.1.gemfile
@@ -1,5 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'prawn', '~> 1.2.1'
-
-gemspec path: '..'

--- a/gemfiles/prawn-2.1.0.gemfile
+++ b/gemfiles/prawn-2.1.0.gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'prawn', '~> 2.0.2'
+gem 'prawn', '~> 2.1.0'
 
 gemspec path: '..'

--- a/lib/prawn/icon.rb
+++ b/lib/prawn/icon.rb
@@ -121,18 +121,12 @@ module Prawn
       def inline_icon(text, opts = {})
         parsed = Icon::Parser.format(self, text)
         content = Text::Formatted::Parser.format(parsed)
-        opts.merge!(
+        box_options = opts.merge(
           inline_format: true,
           document: self,
           at: [bounds.left, cursor]
         )
-        Text::Formatted::Box.new(content, opts).tap do |box|
-          box.render(dry_run: true)
-          self.y -= box.height
-          unless opts.fetch(:final_gap, true)
-            self.y -= box.line_gap + box.leading
-          end
-        end
+        icon_box(content, box_options)
       end
 
       # Initialize a new Prawn::Icon, but don't render
@@ -180,6 +174,18 @@ module Prawn
           make_icon(key, opts).format_hash
         end
       end
+
+      private
+
+      def icon_box(content, opts = {}) # :nodoc:
+        Text::Formatted::Box.new(content, opts).tap do |box|
+          box.render(dry_run: true)
+          self.y -= box.height
+          unless opts.fetch(:final_gap, true)
+            self.y -= box.line_gap + box.leading
+          end
+        end
+      end
     end
 
     attr_reader :set, :unicode
@@ -210,7 +216,7 @@ module Prawn
 
     private
 
-    def strip_specifier_from_key(key) #:nodoc:
+    def strip_specifier_from_key(key) # :nodoc:
       reg = Regexp.new "#{@data.specifier}-"
       key.sub(reg, '') # Only one specifier
     end

--- a/lib/prawn/icon.rb
+++ b/lib/prawn/icon.rb
@@ -119,10 +119,20 @@ module Prawn
       #   underlying text call.
       #
       def inline_icon(text, opts = {})
-        parsed    = Icon::Parser.format(self, text)
-        content   = Text::Formatted::Parser.format(parsed)
-        opts.merge!(inline_format: true, document: self)
-        Text::Formatted::Box.new(content, opts)
+        parsed = Icon::Parser.format(self, text)
+        content = Text::Formatted::Parser.format(parsed)
+        opts.merge!(
+          inline_format: true,
+          document: self,
+          at: [bounds.left, cursor]
+        )
+        Text::Formatted::Box.new(content, opts).tap do |box|
+          box.render(dry_run: true)
+          self.y -= box.height
+          unless opts.fetch(:final_gap, true)
+            self.y -= box.line_gap + box.leading
+          end
+        end
       end
 
       # Initialize a new Prawn::Icon, but don't render

--- a/lib/prawn/icon/version.rb
+++ b/lib/prawn/icon/version.rb
@@ -8,6 +8,6 @@
 
 module Prawn
   class Icon
-    VERSION = '1.1.0'.freeze
+    VERSION = '1.1.1'.freeze
   end
 end

--- a/prawn-icon.gemspec
+++ b/prawn-icon.gemspec
@@ -27,9 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('pdf-inspector', '~> 1.2.1')
   spec.add_development_dependency('rspec', '~> 3.4.0')
   spec.add_development_dependency('rubocop', '~> 0.38.0')
-  spec.add_development_dependency('mocha')
   spec.add_development_dependency('rake')
-  spec.add_development_dependency('simplecov')
   spec.add_development_dependency('pdf-reader', '~> 1.4')
 
   spec.description = <<-END_DESC

--- a/spec/integration/icon_spec.rb
+++ b/spec/integration/icon_spec.rb
@@ -40,6 +40,21 @@ describe Prawn::Icon::Interface do
           expect(text1.strings.first).to eq("\uf047")
           expect(text2.strings.first).to eq("\uf047")
         end
+
+        it 'renders the icon at the proper cursor position (#24)' do
+          icon_text = '<icon>fa-info-circle</icon> icon here!'
+          pdf = create_pdf
+          pdf.text 'Start'
+          pdf.move_down 10
+          pdf.text 'More'
+          pdf.move_down 20
+          icon = pdf.icon icon_text, inline_format: true
+          pdf.move_down 30
+          pdf.text 'End'
+
+          expect(icon.at.first).to eq(0)
+          expect(icon.at.last.round).to eq(734)
+        end
       end
 
       context 'without options' do


### PR DESCRIPTION
This PR fixes a bug reported in #24 that affects the render position of inline icons.

Here's the changes for the following code:

```ruby
Prawn::Document.generate('test.pdf') do |pdf|
  pdf.text 'Start'
  pdf.move_down 10
  pdf.text 'More'
  pdf.move_down 20
  icon = pdf.icon '<icon>fa-info-circle</icon> icon here!', inline_format: true
  pdf.move_down 30
  pdf.text 'End'
end
```

###### Before Fix:
![screen shot 2016-06-24 at 10 36 14 pm](https://cloud.githubusercontent.com/assets/6474230/16354735/1aac39d6-3a5c-11e6-8d15-5eabef087dc5.png)

###### After Fix:
![screen shot 2016-06-24 at 10 37 02 pm](https://cloud.githubusercontent.com/assets/6474230/16354737/37291f84-3a5c-11e6-885e-457e1adc2521.png)

###### Detailed Notes
* Modify `inline_icon` method to render at the cursor position
  and perform a `dry_run` render of the `Text::Formatted::Box` to
  determine the height of the box.
* The y position is then moved down the height of the text box
  (with line gap and leading if applicable).
* Add spec to test for the correct inline icon render position (#24).
* Update version to 1.1.1.
* Update Changelog.