### PR TITLE
feat(fonts) - Configuration of Font Directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,5 @@ Layout/EmptyLineAfterMagicComment:
   Enabled: false
 Layout/IndentHeredoc:
   Enabled: false
+Layout/MultilineMethodCallIndentation:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 * Allow `#formatted_icon_box` to accept absolute positioning parameters (`x`, `y`, and `at`). Thanks @navinspm!
 * Update fontawesome from version `5.11.2` to `5.15.1`.
 * See FontAwesome's [upgrade guide](https://github.com/FortAwesome/Font-Awesome/blob/57005cea6da7d1c67f3466974aecd25485f60452/UPGRADING.md) for more details.
+* Introduce a configuration mechanism so that the font directory can be customized as follows:
+
+```ruby
+Prawn::Icon.configure do |config|
+  config.font_directory = '/path/to/fonts'
+end
+```
+
+* Deprecate the global variables of `Prawn::Icon::Base::FONTDIR` and `Prawn::Icon::Compatibility::SHIMS`. Use `Prawn::Icon.configuration.font_directory` and `Prawn::Icon::Compatibility.shims` instead.
+* Use `Gem::Specification#full_gem_path` to get the root path of the gem directory to resolve https://github.com/jessedoyle/prawn-icon/issues/45.
 
 #### Inline Format Changes
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ rake legend
 
 should generate these files when run from Prawn::Icon's gem directory.
 
+## Configuration
+
+You can optionally configure Prawn::Icon to use an alternate data directory for font files.
+
+```ruby
+Prawn::Icon.configure do |config|
+  config.font_directory = '/path/to/my/fonts'
+end
+```
+
 ## Contributing
 
 I'll gladly accept pull requests that are well tested for any bug found in Prawn::Icon.

--- a/examples/fontawesome.rb
+++ b/examples/fontawesome.rb
@@ -11,8 +11,9 @@ STYLES = {
 
 STYLES.each do |specifier, type|
   Prawn::Document.generate("fontawesome_#{type.downcase}.pdf") do
-    deja_path = File.join \
-      Prawn::Icon::Base::FONTDIR, 'DejaVuSans.ttf'
+    deja_path = Prawn::Icon.configuration.font_directory
+      .join('DejaVuSans.ttf')
+      .to_s
 
     font_families.update(
       'deja' => { normal: deja_path }

--- a/examples/foundation_icons.rb
+++ b/examples/foundation_icons.rb
@@ -4,8 +4,9 @@ require_relative '../lib/prawn/icon'
 require_relative 'example_helper'
 
 Prawn::Document.generate('foundation_icons.pdf') do
-  deja_path = File.join \
-    Prawn::Icon::Base::FONTDIR, 'DejaVuSans.ttf'
+  deja_path = Prawn::Icon.configuration.font_directory
+    .join('DejaVuSans.ttf')
+    .to_s
 
   font_families.update({
     'deja' => { normal: deja_path }

--- a/examples/paymentfont.rb
+++ b/examples/paymentfont.rb
@@ -4,8 +4,9 @@ require_relative '../lib/prawn/icon'
 require_relative 'example_helper'
 
 Prawn::Document.generate('paymentfont.pdf') do
-  deja_path = File.join \
-    Prawn::Icon::Base::FONTDIR, 'DejaVuSans.ttf'
+  deja_path = Prawn::Icon.configuration.font_directory
+    .join('DejaVuSans.ttf')
+    .to_s
 
   font_families.update({
     'deja' => { normal: deja_path }

--- a/lib/prawn/icon.rb
+++ b/lib/prawn/icon.rb
@@ -6,7 +6,9 @@
 #
 # This is free software. Please see the LICENSE and COPYING files for details.
 
+require 'pathname'
 require_relative 'icon/version'
+require_relative 'icon/configuration'
 require_relative 'icon/base'
 require_relative 'icon/font_data'
 require_relative 'icon/parser'

--- a/lib/prawn/icon/base.rb
+++ b/lib/prawn/icon/base.rb
@@ -11,9 +11,21 @@ require_relative 'errors'
 
 module Prawn
   class Icon
+    class << self
+      attr_writer :configuration
+
+      def configuration
+        @configuration ||= Configuration.new
+      end
+
+      def configure
+        yield(configuration)
+      end
+    end
+
     module Base
-      FONTDIR = File.join \
-        File.expand_path('../../../..', __FILE__), 'data/fonts'
+      # @deprecated Use {Prawn::Icon.configuration.font_directory} instead
+      FONTDIR = Prawn::Icon.configuration.font_directory.to_s
     end
   end
 end

--- a/lib/prawn/icon/compatibility.rb
+++ b/lib/prawn/icon/compatibility.rb
@@ -9,13 +9,21 @@
 module Prawn
   class Icon
     class Compatibility
+      # @deprecated Use {Prawn::Icon::Compatibility.shims} instead
       SHIMS = YAML.load_file(
-        File.join(
-          Base::FONTDIR,
+        Prawn::Icon.configuration.font_directory.join(
           'fa4',
           'shims.yml'
         )
       ).freeze
+
+      class << self
+        def shims
+          @shims ||= YAML.load_file(
+            Icon.configuration.font_directory.join('fa4', 'shims.yml').to_s
+          )
+        end
+      end
 
       attr_accessor :key
 
@@ -36,7 +44,7 @@ module Prawn
       private
 
       def map
-        SHIMS.fetch(key) do
+        self.class.shims.fetch(key) do
           # FontAwesome shim metadata assumes "fas" as the default
           # font family if not explicity referenced.
           "fas-#{key.sub(/fa-/, '')}"

--- a/lib/prawn/icon/configuration.rb
+++ b/lib/prawn/icon/configuration.rb
@@ -1,0 +1,40 @@
+# encoding: utf-8
+#
+# configuration.rb: Prawn icon configuration.
+#
+# Copyright October 2020, Jesse Doyle. All rights reserved.
+#
+# This is free software. Please see the LICENSE and COPYING files for details.
+
+module Prawn
+  class Icon
+    class Configuration
+      def font_directory=(path)
+        @font_directory = Pathname.new(path)
+      end
+
+      def font_directory
+        @font_directory ||= default_font_directory
+      end
+
+      private
+
+      def default_font_directory
+        Pathname.new(gem_path).join('data', 'fonts')
+      end
+
+      # :nocov:
+      def gem_path
+        spec = Gem.loaded_specs.fetch('prawn-icon') do
+          Struct.new(:full_gem_path).new(failsafe_gem_path)
+        end
+        spec.full_gem_path
+      end
+
+      def failsafe_gem_path
+        File.expand_path('../../../..', __FILE__)
+      end
+      # :nocov:
+    end
+  end
+end

--- a/lib/prawn/icon/font_data.rb
+++ b/lib/prawn/icon/font_data.rb
@@ -63,15 +63,17 @@ module Prawn
       end
 
       def path
-        ttf  = File.join(Icon::Base::FONTDIR, @set.to_s, '*.ttf')
-        font = Dir[ttf].first
+        font = Icon.configuration.font_directory
+          .join(@set.to_s)
+          .glob('*.ttf')
+          .first
 
         if font.nil?
           raise Prawn::Errors::UnknownFont,
                 "Icon font not found for set: #{@set}"
         end
 
-        @path ||= font
+        @path ||= font.to_s
       end
 
       def specifier

--- a/lib/prawn/icon/interface.rb
+++ b/lib/prawn/icon/interface.rb
@@ -19,7 +19,7 @@ module Prawn
   # rule, included icon keys should match the keys from
   # the font provider. The icon key mapping is specified
   # in the font's +legend_file+, which is a +YAML+ file
-  # located in Prawn::Icon::Base::FONTDIR/font/font.yml.
+  # located in {Prawn::Icon.configuration.font_directory}/font/font.yml.
   #
   # Prawn::Icon::
   #   Houses the methods and interfaces necessary for
@@ -38,6 +38,7 @@ module Prawn
   #   to Prawn's internal formatted text parser.
   #
   class Icon
+    # @deprecated Use {Prawn::Icon.configuration.font_directory} instead
     FONTDIR = Icon::Base::FONTDIR
 
     module Interface

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -4,12 +4,31 @@
 #
 # This is free software. Please see the LICENSE and COPYING files for details.
 
-describe Prawn::Icon::Base do
-  describe 'FONTDIR' do
-    it 'returns the data/fonts directory' do
-      path = File.expand_path '../../..', __FILE__
-      path = File.join path, 'data/fonts'
-      expect(Prawn::Icon::Base::FONTDIR).to eq(path)
+describe Prawn::Icon do
+  describe '#configuration' do
+    it 'returns an instance of Prawn::Icon::Configuration' do
+      expect(described_class.configuration).to be_a(Prawn::Icon::Configuration)
+    end
+  end
+
+  describe '#configure' do
+    around(:each) do |example|
+      old = described_class.configuration.dup
+      described_class.configure do |config|
+        config.font_directory = '/tmp/fonts'
+      end
+      example.run
+      described_class.configuration = old
+    end
+
+    it 'yields control' do
+      expect { |b| described_class.configure(&b) }.to yield_control
+    end
+
+    it 'configures properties' do
+      expect(described_class.configuration.font_directory).to eq(
+        Pathname.new('/tmp/fonts')
+      )
     end
   end
 end

--- a/spec/unit/configuration_spec.rb
+++ b/spec/unit/configuration_spec.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+#
+# Copyright October 2020, Jesse Doyle. All rights reserved.
+#
+# This is free software. Please see the LICENSE and COPYING files for details.
+
+describe Prawn::Icon::Configuration do
+  describe '#font_directory' do
+    before(:each) do
+      subject.font_directory = '/tmp/fakedir'
+    end
+
+    it 'returns a Pathname' do
+      expect(subject.font_directory).to be_a(Pathname)
+    end
+
+    it 'returns the configured path' do
+      expect(subject.font_directory.to_s).to eq('/tmp/fakedir') 
+    end
+  end
+end


### PR DESCRIPTION
resolves #45

* Introduce a standard gem configuration interface that allows
  users to set an alternate font directory as follows:

```ruby
Prawn::Icon.configure do |config|
  config.font_directory = '/foo/bar'
end
```

* Formally deprecate the `FONTDIR` and `SHIMS` constants and replace
  with memoized class variables. We're only keeping them around so
  as to not release a breaking change.
* Bump version to 2.6.0.
* Fix a bug with directory pathing in some environments because the
  path was built assuming consistent namespacing. We now use
  `Gem::Specification#full_gem_path` to handle the inconsistencies.
* Disable the rubocop `Layout/MultilineMethodCallIndentation` check
  as it adds more whitespace than I prefer.