### PR TITLE
fix(inline): Inline Icon Page Wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 3.0.0 - November 10, 2020
+
+* **breaking change** - Fix incorrect layout and line-wrapping logic for inline-formatted icons. Please see [Inline Format Changes](#inline-format-changes) for more details.
+* Add a `#formatted_icon_box` method to retain the previous inline icon behaviour.
+* Allow `#formatted_icon_box` to accept absolute positioning parameters (`x`, `y`, and `at`). Thanks @navinspm!
+
+#### Inline Format Changes
+
+As noted in https://github.com/jessedoyle/prawn-icon/issues/49, `Prawn::Icon` did not correctly respect page boundaries for inline-formatted icons.
+
+The fix for the issue requires `Prawn::Icon` to use the inline layout and formatting logic implemented in `Prawn`.
+
+This change has ramifications to the `#icon` and `#inline_icon` method return values, but most applications should not require changes.
+
+Changes are listed below:
+
+* `#icon` - returns `nil` with the `inline_format: true` parameter.
+* `#inline_icon` - returns `nil` (instead of a `Prawn::Text::Formatted::Box` instance).
+
+You can call `#formatted_icon_box` to retain the previous inline icon functionality.
+
 # 2.5.0 - October 4, 2019
 
 * Update FontAwesome from `5.8.2` to `5.11.2`.

--- a/lib/prawn/icon/compatibility.rb
+++ b/lib/prawn/icon/compatibility.rb
@@ -48,7 +48,7 @@ module Prawn
 [Prawn::Icon - DEPRECATION WARNING]
   FontAwesome 4 icon was referenced as '#{old_key}'.
   Use the FontAwesome 5 icon '#{new_key}' instead.
-  This compatibility layer will be removed in Prawn::Icon 3.0.0.
+  This compatibility layer will be removed in Prawn::Icon 4.0.0.
 DEPRECATION
       end
     end

--- a/lib/prawn/icon/interface.rb
+++ b/lib/prawn/icon/interface.rb
@@ -63,11 +63,10 @@ module Prawn
       #
       def icon(key, opts = {})
         key = translate_key(key)
-        make_icon(key, opts).tap(&:render)
+        make_icon(key, opts).tap { |i| i && i.render }
       end
 
-      # Initialize a new icon object, but do
-      # not render it to the document.
+      # Initialize a new icon object.
       #
       # == Parameters:
       # key::
@@ -90,9 +89,9 @@ module Prawn
         end
       end
 
-      # Initialize a new formatted text box containing
-      # icon information, but don't render it to the
-      # document.
+      # Render formatted icon content to the document from
+      # a string containing icons. Content will correctly
+      # transition to a new page when necessary.
       #
       # == Parameters:
       # text::
@@ -107,10 +106,37 @@ module Prawn
       def inline_icon(text, opts = {})
         parsed = Icon::Parser.format(self, text)
         content = Text::Formatted::Parser.format(parsed)
+        formatted_text(content, opts)
+      end
+
+      # Initialize a formatted icon box from an icon-conatining
+      # string. Content is not directly rendered to the document,
+      # instead a +Prawn::Text::Formatted::Box+ instance is returned
+      # that responds to the +render+ method.
+      #
+      # == Parameters:
+      # text::
+      #   Input text to be parsed initially for <icon>
+      #   tags, then passed to Prawn's formatted text
+      #   parser.
+      #
+      # opts::
+      #   A hash of options that may be supplied to the
+      #   underlying text call.
+      #
+      def formatted_icon_box(text, opts = {})
+        parsed = Icon::Parser.format(self, text)
+        content = Text::Formatted::Parser.format(parsed)
+        position = opts.fetch(:at) do
+          [
+            opts.fetch(:x) { bounds.left },
+            opts.fetch(:y) { cursor }
+          ]
+        end
         box_options = opts.merge(
           inline_format: true,
           document: self,
-          at: [bounds.left, cursor]
+          at: position
         )
         icon_box(content, box_options)
       end

--- a/lib/prawn/icon/version.rb
+++ b/lib/prawn/icon/version.rb
@@ -8,6 +8,6 @@
 
 module Prawn
   class Icon
-    VERSION = '2.5.0'.freeze
+    VERSION = '3.0.0'.freeze
   end
 end


### PR DESCRIPTION
* Previously inline formatted icons would not correctly start a
  new page when necessary, so the formatted text box would render
  at a cursor position that made it invisible.
* Add a new test case for the bug outlined in #49.
* Adjust `#inline_icon` to directly call Prawn's `#formatted_text`
  method with the transformed inline formatted string.
* The previous implementation of `#inline_icon` went to great
  lengths to position the formatted text box without rendering to
  the document, but Prawn's formatted text box wrapping logic may
  require multiple `Prawn::Text::Formatted::Box` instances (around
  page breaks).
* Due to this change `#inline_icon` calls now return `nil` and
  content is rendered immediately to the document.
* This change also means that `#icon` calls will return `nil`
  when using the `inline_format: true` parameter.
* Add a `#formatted_icon_box` method that retains the previous
  inline icon behaviour.
* Allow `#formatted_icon_box` to accept the `:at`, `:x` and `:y`
  absolute positioning parameters (Thanks @navisnspm!).
* Transition to `Pdf::Inspector` to make positioning decisions
  in specs. This is a more comprehensive test expectation.
* Change the deprecation message for the FontAwesome 4
  shim to include a future 4.X version as the compatibility
  layer will be maintained for at least another major version.
* Update major version to 3.0.0 as the return values have
  changed in the public API `#icon` and `#inline_icon` methods.

resolves https://github.com/jessedoyle/prawn-icon/issues/49