### PR TITLE
Expand the CI matrix to include recent versions of Prawn and Ruby

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,24 +15,19 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '2.6'
           - '2.7'
-          - '3.0'
+          - '3.1'
         gemfile:
           - gemfiles/prawn-1.3.0.gemfile
-          - gemfiles/prawn-2.2.0.gemfile
-          - gemfiles/prawn-2.3.0.gemfile
           - gemfiles/prawn-2.4.0.gemfile
           - gemfiles/prawn-master.gemfile
         exclude:
-          - ruby: '3.0'
+          - ruby: '3.1'
             gemfile: gemfiles/prawn-1.3.0.gemfile
-          - ruby: '3.0'
-            gemfile: gemfiles/prawn-2.2.0.gemfile
-          - ruby: '3.0'
-            gemfile: gemfiles/prawn-2.3.0.gemfile
+          - ruby: '3.1'
+            gemfile: gemfiles/prawn-2.4.0.gemfile
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,29 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - '2.6'
           - '2.7'
+          - '3.0'
         gemfile:
           - gemfiles/prawn-1.3.0.gemfile
           - gemfiles/prawn-2.2.0.gemfile
+          - gemfiles/prawn-2.3.0.gemfile
+          - gemfiles/prawn-2.4.0.gemfile
           - gemfiles/prawn-master.gemfile
+        exclude:
+          - ruby: '3.0'
+            gemfile: gemfiles/prawn-1.3.0.gemfile
+          - ruby: '3.0'
+            gemfile: gemfiles/prawn-2.2.0.gemfile
+          - ruby: '3.0'
+            gemfile: gemfiles/prawn-2.3.0.gemfile
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Build and test with Rake

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 coverage/
 vendor/bundle
 .bundle
+/*.pdf

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,26 +4,23 @@ AllCops:
     - 'examples/**/*'
     - 'spec/**/*'
     - 'Rakefile'
-MethodLength:
+  NewCops: enable
+  SuggestExtensions: false
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+Metrics/MethodLength:
   Max: 25
-SignalException:
+Style/SignalException:
   EnforcedStyle: only_raise
-Documentation:
+Style/Documentation:
   Enabled: false
-RegexpLiteral:
+Style/RegexpLiteral:
   Enabled: false
-SpaceAroundOperators:
-  Enabled: false
-FirstParameterIndentation:
-  Enabled: false
+Style/SafeNavigation:
+  Exclude:
+    - lib/prawn/icon/interface.rb
 Metrics/AbcSize:
   Max: 20
-Layout/EmptyLineAfterMagicComment:
-  Enabled: false
-Layout/HeredocIndentation:
-  Enabled: false
-Layout/MultilineMethodCallIndentation:
-  Enabled: false
 Naming/FileName:
   Exclude:
     - gemfiles/*.gemfile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,15 +14,16 @@ RegexpLiteral:
   Enabled: false
 SpaceAroundOperators:
   Enabled: false
-RedundantMerge:
-  Enabled: false
 FirstParameterIndentation:
   Enabled: false
 Metrics/AbcSize:
   Max: 20
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 Layout/MultilineMethodCallIndentation:
   Enabled: false
+Naming/FileName:
+  Exclude:
+    - gemfiles/*.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.1.0 - September 1, 2022
+
+* Update our CI matrix to include recent versions of Prawn and Ruby! Thanks @petergoldstein! (#55)
+* Resolve a few code smells that were flagged by Rubocop.
+
 # 3.0.0 - November 10, 2020
 
 * **breaking change** - Fix incorrect layout and line-wrapping logic for inline-formatted icons. Please see [Inline Format Changes](#inline-format-changes) for more details.

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/gemfiles/prawn-1.3.0.gemfile
+++ b/gemfiles/prawn-1.3.0.gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'prawn', '~> 1.3.0'

--- a/gemfiles/prawn-2.2.0.gemfile
+++ b/gemfiles/prawn-2.2.0.gemfile
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-source 'https://rubygems.org'
-
-gem 'prawn', '~> 2.3.0'
-
-gemspec path: '..'

--- a/gemfiles/prawn-2.2.0.gemfile
+++ b/gemfiles/prawn-2.2.0.gemfile
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'prawn', '~> 2.2.0'
+gem 'prawn', '~> 2.3.0'
 
 gemspec path: '..'

--- a/gemfiles/prawn-2.3.0.gemfile
+++ b/gemfiles/prawn-2.3.0.gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'prawn', '~> 1.3.0'
+gem 'prawn', '~> 2.2.0'
 
 gemspec path: '..'

--- a/gemfiles/prawn-2.3.0.gemfile
+++ b/gemfiles/prawn-2.3.0.gemfile
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-source 'https://rubygems.org'
-
-gem 'prawn', '~> 2.2.0'
-
-gemspec path: '..'

--- a/gemfiles/prawn-2.4.0.gemfile
+++ b/gemfiles/prawn-2.4.0.gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
-gem 'prawn', '~> 1.3.0'
+gem 'prawn', '~> 2.4.0'
 
 gemspec path: '..'

--- a/gemfiles/prawn-2.4.0.gemfile
+++ b/gemfiles/prawn-2.4.0.gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'prawn', '~> 2.4.0'

--- a/gemfiles/prawn-master.gemfile
+++ b/gemfiles/prawn-master.gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 gem 'prawn', git: 'https://github.com/prawnpdf/prawn'

--- a/gemfiles/prawn-master.gemfile
+++ b/gemfiles/prawn-master.gemfile
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'prawn', git: 'https://github.com/prawnpdf/prawn'

--- a/lib/prawn/icon.rb
+++ b/lib/prawn/icon.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # icon.rb: Prawn icon functionality.
 #
 # Copyright October 2014, Jesse Doyle. All rights reserved.

--- a/lib/prawn/icon.rb
+++ b/lib/prawn/icon.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 #
 # icon.rb: Prawn icon functionality.
 #

--- a/lib/prawn/icon/base.rb
+++ b/lib/prawn/icon/base.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # base.rb - Base configuration for Prawn::Icon.
 #
 # Copyright September 2016, Jesse Doyle. All rights reserved.

--- a/lib/prawn/icon/base.rb
+++ b/lib/prawn/icon/base.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 #
 # base.rb - Base configuration for Prawn::Icon.
 #

--- a/lib/prawn/icon/compatibility.rb
+++ b/lib/prawn/icon/compatibility.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # compatibility.rb - Prawn::Icon FontAwesome 4/5 compatibility shim.
 #
 # Copyright March 2018, Jesse Doyle. All rights reserved.
@@ -50,11 +50,11 @@ module Prawn
       end
 
       def warning(new_key, old_key, io)
-        io.puts <<-DEPRECATION
-[Prawn::Icon - DEPRECATION WARNING]
-  FontAwesome 4 icon was referenced as '#{old_key}'.
-  Use the FontAwesome 5 icon '#{new_key}' instead.
-  This compatibility layer will be removed in Prawn::Icon 4.0.0.
+        io.puts <<~DEPRECATION
+          [Prawn::Icon - DEPRECATION WARNING]
+            FontAwesome 4 icon was referenced as '#{old_key}'.
+            Use the FontAwesome 5 icon '#{new_key}' instead.
+            This compatibility layer will be removed in Prawn::Icon 4.0.0.
         DEPRECATION
       end
     end

--- a/lib/prawn/icon/compatibility.rb
+++ b/lib/prawn/icon/compatibility.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 #
 # compatibility.rb - Prawn::Icon FontAwesome 4/5 compatibility shim.
 #
@@ -31,14 +31,12 @@ module Prawn
         self.key = opts.fetch(:key)
       end
 
-      def translate(io = STDERR)
-        @translate ||= begin
-          if key.start_with?('fa-')
-            map.tap { |replaced| warning(replaced, key, io) }
-          else
-            key
-          end
-        end
+      def translate(io = $stderr)
+        @translate ||= if key.start_with?('fa-')
+                         map.tap { |replaced| warning(replaced, key, io) }
+                       else
+                         key
+                       end
       end
 
       private
@@ -57,9 +55,8 @@ module Prawn
   FontAwesome 4 icon was referenced as '#{old_key}'.
   Use the FontAwesome 5 icon '#{new_key}' instead.
   This compatibility layer will be removed in Prawn::Icon 4.0.0.
-DEPRECATION
+        DEPRECATION
       end
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/lib/prawn/icon/configuration.rb
+++ b/lib/prawn/icon/configuration.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # configuration.rb: Prawn icon configuration.
 #
 # Copyright October 2020, Jesse Doyle. All rights reserved.

--- a/lib/prawn/icon/configuration.rb
+++ b/lib/prawn/icon/configuration.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 #
 # configuration.rb: Prawn icon configuration.
 #
@@ -32,7 +32,7 @@ module Prawn
       end
 
       def failsafe_gem_path
-        File.expand_path('../../../..', __FILE__)
+        File.expand_path('../../..', __dir__)
       end
       # :nocov:
     end

--- a/lib/prawn/icon/errors.rb
+++ b/lib/prawn/icon/errors.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 #
 # errors.rb - Prawn::Icon standard errors.
 #

--- a/lib/prawn/icon/errors.rb
+++ b/lib/prawn/icon/errors.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # errors.rb - Prawn::Icon standard errors.
 #
 # Copyright September 2016, Jesse Doyle. All rights reserved.

--- a/lib/prawn/icon/font_data.rb
+++ b/lib/prawn/icon/font_data.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # font_data.rb: Icon font metadata container/cache.
 #
 # Copyright October 2014, Jesse Doyle. All rights reserved.
@@ -64,9 +64,9 @@ module Prawn
 
       def path
         font = Icon.configuration.font_directory
-          .join(@set.to_s)
-          .glob('*.ttf')
-          .first
+                   .join(@set.to_s)
+                   .glob('*.ttf')
+                   .first
 
         if font.nil?
           raise Prawn::Errors::UnknownFont,

--- a/lib/prawn/icon/font_data.rb
+++ b/lib/prawn/icon/font_data.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 #
 # font_data.rb: Icon font metadata container/cache.
 #

--- a/lib/prawn/icon/interface.rb
+++ b/lib/prawn/icon/interface.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # interface.rb: Prawn extension module and logic.
 #
 # Copyright October 2016, Jesse Doyle. All rights reserved.
@@ -64,7 +64,7 @@ module Prawn
       #
       def icon(key, opts = {})
         key = translate_key(key)
-        make_icon(key, opts).tap { |i| i&.render }
+        make_icon(key, opts).tap { |i| i && i.render }
       end
 
       # Initialize a new icon object.

--- a/lib/prawn/icon/interface.rb
+++ b/lib/prawn/icon/interface.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 #
 # interface.rb: Prawn extension module and logic.
 #
@@ -64,7 +64,7 @@ module Prawn
       #
       def icon(key, opts = {})
         key = translate_key(key)
-        make_icon(key, opts).tap { |i| i && i.render }
+        make_icon(key, opts).tap { |i| i&.render }
       end
 
       # Initialize a new icon object.
@@ -199,9 +199,7 @@ module Prawn
         Text::Formatted::Box.new(content, opts).tap do |box|
           box.render(dry_run: true)
           self.y -= box.height
-          unless opts.fetch(:final_gap, true)
-            self.y -= box.line_gap + box.leading
-          end
+          self.y -= box.line_gap + box.leading unless opts.fetch(:final_gap, true)
         end
       end
     end

--- a/lib/prawn/icon/parser.rb
+++ b/lib/prawn/icon/parser.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # parser.rb: Prawn icon tag text parser (pseudo-HTML).
 #
 # Copyright October 2014, Jesse Doyle. All rights reserved.

--- a/lib/prawn/icon/parser.rb
+++ b/lib/prawn/icon/parser.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 #
 # parser.rb: Prawn icon tag text parser (pseudo-HTML).
 #
@@ -31,15 +31,17 @@ module Prawn
     #
     class Parser
       PARSER_REGEX  = Regexp.new \
-                      '<icon[^>]*>|</icon>',
-                      Regexp::IGNORECASE |
-                      Regexp::MULTILINE
+        '<icon[^>]*>|</icon>',
+        Regexp::IGNORECASE |
+        Regexp::MULTILINE
 
-      CONTENT_REGEX = /<icon[^>]*>(?<content>[^<]*)<\/icon>/mi
+      CONTENT_REGEX = /<icon[^>]*>(?<content>[^<]*)<\/icon>/mi.freeze
 
-      TAG_REGEX     = /<icon[^>]*>[^<]*<\/icon>/mi
+      TAG_REGEX     = /<icon[^>]*>[^<]*<\/icon>/mi.freeze
 
-      ATTR_REGEX    = /(?<attr>[a-zA-Z]*)=["|'](?<val>(\w*[^["|']]))["|']/mi
+      # rubocop:disable Lint/MixedRegexpCaptureTypes
+      ATTR_REGEX    = /(?<attr>[a-zA-Z]*)=["|'](?<val>(\w*[^["|']]))["|']/mi.freeze
+      # rubocop:enable Lint/MixedRegexpCaptureTypes
 
       class << self
         def format(document, string)
@@ -103,9 +105,9 @@ module Prawn
               options ||= {}
               options = config[index] if config.any?
               info = {
-                set:     FontData.specifier_from_key(key),
-                size:    options[:size],
-                color:   options[:color],
+                set: FontData.specifier_from_key(key),
+                size: options[:size],
+                color: options[:color],
                 content: FontData.unicode_from_key(document, key)
               }
               icons << info
@@ -115,7 +117,7 @@ module Prawn
 
         private
 
-        def attr_hash(value) #:nodoc:
+        def attr_hash(value) # :nodoc:
           # If attr == size, we must cast value to float,
           # else symbolize the key and map it to value
           if value[0] =~ /size/i

--- a/lib/prawn/icon/version.rb
+++ b/lib/prawn/icon/version.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# frozen_string_literal: true
 #
 # version.rb: Prawn icon versioning.
 #
@@ -8,6 +8,6 @@
 
 module Prawn
   class Icon
-    VERSION = '3.0.0'.freeze
+    VERSION = '3.0.0'
   end
 end

--- a/lib/prawn/icon/version.rb
+++ b/lib/prawn/icon/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # version.rb: Prawn icon versioning.
 #
 # Copyright October 2014, Jesse Doyle. All rights reserved.
@@ -8,6 +8,6 @@
 
 module Prawn
   class Icon
-    VERSION = '3.0.0'
+    VERSION = '3.1.0'
   end
 end

--- a/prawn-icon.gemspec
+++ b/prawn-icon.gemspec
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 basedir = __dir__
 require "#{basedir}/lib/prawn/icon/version"
 
@@ -13,12 +14,11 @@ Gem::Specification.new do |spec|
                    %w[COPYING LICENSE GPLv2 GPLv3]
 
   spec.require_path              = 'lib'
-  spec.required_ruby_version     = '>= 2.6'
-  spec.required_rubygems_version = '>= 2.0.0'
+  spec.required_ruby_version     = '>= 1.9.3'
+  spec.required_rubygems_version = '>= 1.3.6'
 
   spec.homepage = 'https://github.com/jessedoyle/prawn-icon/'
 
-  spec.test_files = Dir['spec/*_spec.rb']
   spec.authors    = ['Jesse Doyle']
   spec.email      = ['jdoyle@ualberta.ca']
   spec.licenses   = %w[RUBY GPL-2 GPL-3]
@@ -29,12 +29,13 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('pdf-reader', '>= 1.4')
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rspec', '>= 3.5.0')
-  spec.add_development_dependency('rubocop', '~> 1.0')
+  spec.add_development_dependency('rubocop', '~> 1.35.1')
   spec.add_development_dependency('simplecov')
 
-  spec.description = <<-END_DESC
-  Prawn::Icon provides various icon fonts including
-  FontAwesome, PaymentFont and Foundation Icons
-  for use with the Prawn PDF toolkit.
+  spec.description = <<~END_DESC
+    Prawn::Icon provides various icon fonts including
+    FontAwesome, PaymentFont and Foundation Icons
+    for use with the Prawn PDF toolkit.
   END_DESC
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/prawn-icon.gemspec
+++ b/prawn-icon.gemspec
@@ -1,4 +1,5 @@
-basedir = File.expand_path(File.dirname(__FILE__))
+# frozen_string_literal: true
+basedir = __dir__
 require "#{basedir}/lib/prawn/icon/version"
 
 Gem::Specification.new do |spec|
@@ -12,23 +13,23 @@ Gem::Specification.new do |spec|
                    %w[COPYING LICENSE GPLv2 GPLv3]
 
   spec.require_path              = 'lib'
-  spec.required_ruby_version     = '>= 1.9.3'
-  spec.required_rubygems_version = '>= 1.3.6'
+  spec.required_ruby_version     = '>= 2.6'
+  spec.required_rubygems_version = '>= 2.0.0'
 
   spec.homepage = 'https://github.com/jessedoyle/prawn-icon/'
 
   spec.test_files = Dir['spec/*_spec.rb']
   spec.authors    = ['Jesse Doyle']
   spec.email      = ['jdoyle@ualberta.ca']
-  spec.licenses   = ['RUBY', 'GPL-2', 'GPL-3']
+  spec.licenses   = %w[RUBY GPL-2 GPL-3]
 
   spec.add_dependency('prawn', '>= 1.1.0', '< 3.0.0')
 
   spec.add_development_dependency('pdf-inspector', '>= 1.2.1')
-  spec.add_development_dependency('rspec', '>= 3.5.0')
-  spec.add_development_dependency('rubocop', '~> 0.49.1')
-  spec.add_development_dependency('rake')
   spec.add_development_dependency('pdf-reader', '>= 1.4')
+  spec.add_development_dependency('rake')
+  spec.add_development_dependency('rspec', '>= 3.5.0')
+  spec.add_development_dependency('rubocop', '~> 1.0')
   spec.add_development_dependency('simplecov')
 
   spec.description = <<-END_DESC

--- a/tool/fontawesome.rb
+++ b/tool/fontawesome.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # tool/fontawesome.rb: Convert Fontawesome SCSS variables to YAML legend.
 #
 # Copyright September 2017, Jesse Doyle. All rights reserved.
@@ -9,7 +9,7 @@
 require_relative 'fontawesome/converter'
 
 puts 'Please enter the path to the icons.yml metadata file ' \
-'(i.e. fontawesome-free/advanced-options/icons.yml):'
+     '(i.e. fontawesome-free/advanced-options/icons.yml):'
 path = File.expand_path(gets.chomp)
 output = File.expand_path('data/fonts')
 puts 'Please enter the font version:'

--- a/tool/fontawesome.rb
+++ b/tool/fontawesome.rb
@@ -1,5 +1,4 @@
-# encoding: utf-8
-
+# frozen_string_literal: true
 #
 # tool/fontawesome.rb: Convert Fontawesome SCSS variables to YAML legend.
 #

--- a/tool/fontawesome/converter.rb
+++ b/tool/fontawesome/converter.rb
@@ -1,5 +1,4 @@
-# encoding: utf-8
-
+# frozen_string_literal: true
 #
 # tool/fontawesome/converter.rb: Convert FontAweomse metadata to YAML.
 #

--- a/tool/fontawesome/converter.rb
+++ b/tool/fontawesome/converter.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # tool/fontawesome/converter.rb: Convert FontAweomse metadata to YAML.
 #
 # Copyright March 2018, Jesse Doyle. All rights reserved.

--- a/tool/paymentfont.rb
+++ b/tool/paymentfont.rb
@@ -1,5 +1,4 @@
-# encoding: utf-8
-
+# frozen_string_literal: true
 #
 # tool/fontawesome.rb: Convert PaymentFont SCSS variables to YAML legend.
 #
@@ -9,8 +8,8 @@
 
 require_relative 'scss/parser'
 
-PREFIX = /pf-var-(?<key>.+):\s*"\\(?<unicode>.*)";/
-VERSION = /pf-version:\s*"(?<version>.*)"/
+PREFIX = /pf-var-(?<key>.+):\s*"\\(?<unicode>.*)";/.freeze
+VERSION = /pf-version:\s*"(?<version>.*)"/.freeze
 
 puts 'Please enter in the path to the _variables.scss file:'
 path = File.expand_path(gets.chomp)

--- a/tool/paymentfont.rb
+++ b/tool/paymentfont.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # tool/fontawesome.rb: Convert PaymentFont SCSS variables to YAML legend.
 #
 # Copyright September 2017, Jesse Doyle. All rights reserved.

--- a/tool/scss/parser.rb
+++ b/tool/scss/parser.rb
@@ -1,5 +1,4 @@
-# encoding: utf-8
-
+# frozen_string_literal: true
 #
 # tool/scss/parser.rb: Convert SCSS variables to YAML legend.
 #

--- a/tool/scss/parser.rb
+++ b/tool/scss/parser.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 # tool/scss/parser.rb: Convert SCSS variables to YAML legend.
 #
 # Copyright September 2017, Jesse Doyle. All rights reserved.


### PR DESCRIPTION
This PR adds Prawn 2.4 and Ruby 3.1 the CI matrix.
This PR also: 

- Addresses a number of Rubocop issues to get things green
- Adds PDFs in the root to .gitignore to avoid accidentally committing rake legend output
- Bumps the minimum Ruby version in the gemspec to 2.6