### PR TITLE
optimize(fonts): Memoize Font Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Update our CI matrix to include recent versions of Prawn and Ruby! Thanks @petergoldstein! (#55)
 * Resolve a few code smells that were flagged by Rubocop.
 * [Material Design Icons](https://materialdesignicons.com) are now supported! Currently version `7.0.96` is included. Thanks @maneex! [https://github.com/jessedoyle/prawn-icon/pull/59](Pull Request).
+* Memoize calls to `Prawn::Icon::FontData#path` to improve performance.
 
 #### Material Design Icons
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Prawn::Icon provides a simple mechanism for rendering icons and icon fonts from 
 The following icon fonts ship with Prawn::Icon:
 
 * FontAwesome (http://fontawesome.io/icons/)
+* Material Design Icons (https://materialdesignicons.com/)
 * Foundation Icons (http://zurb.com/playground/foundation-icon-fonts-3)
 * PaymentFont (https://paymentfont.com)
 

--- a/lib/prawn/icon/font_data.rb
+++ b/lib/prawn/icon/font_data.rb
@@ -63,17 +63,19 @@ module Prawn
       end
 
       def path
-        font = Icon.configuration.font_directory
-                   .join(@set.to_s)
-                   .glob('*.ttf')
-                   .first
+        @path = begin
+          font = Icon.configuration.font_directory
+                     .join(@set.to_s)
+                     .glob('*.ttf')
+                     .first
 
-        if font.nil?
-          raise Prawn::Errors::UnknownFont,
-                "Icon font not found for set: #{@set}"
+          if font.nil?
+            raise Prawn::Errors::UnknownFont,
+                  "Icon font not found for set: #{@set}"
+          end
+
+          font.to_s
         end
-
-        @path ||= font.to_s
       end
 
       def specifier


### PR DESCRIPTION
* Memoize the `Prawn::Icon::FontData#path` method as it performs
  a filesystem glob and is currently as hot code path.
* Update the README to include Material Design Icons.