### PR TITLE
chore: Fix Broken Readme Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Prawn::Icon
 
 [![Gem Version](https://badge.fury.io/rb/prawn-icon.svg)](http://badge.fury.io/rb/prawn-icon)
-[![Build Status](https://api.travis-ci.org/jessedoyle/prawn-icon.svg?branch=master)](http://travis-ci.org/jessedoyle/prawn-icon)
-[![Code Climate](https://codeclimate.com/github/jessedoyle/prawn-icon/badges/gpa.svg)](https://codeclimate.com/github/jessedoyle/prawn-icon)
+![Build Status](https://github.com/jessedoyle/prawn-icon/actions/workflows/ci.yml/badge.svg?branch=master)
 
 Prawn::Icon provides a simple mechanism for rendering icons and icon fonts from within [Prawn](https://github.com/prawnpdf/prawn).
 


### PR DESCRIPTION
* Remove the codeclimate badge as it's not used in this project
* Replace the Travis badge with GitHub Actions against master